### PR TITLE
Test refactor, timeout=0 fix, and PIDLockFile fix

### DIFF
--- a/lockfile/__init__.py
+++ b/lockfile/__init__.py
@@ -154,8 +154,10 @@ class NotMyLock(UnlockError):
     """
     pass
 
-class LockBase:
+
+class LockBase(object):
     """Base class for platform-specific lock classes."""
+
     def __init__(self, path, threaded=True, timeout=None):
         """
         >>> lock = LockBase('somefile')
@@ -174,10 +176,10 @@ class LockBase:
         else:
             self.tname = ""
         dirname = os.path.dirname(self.lock_file)
+        self.unique_id = "%s.%s" % (self.tname, self.pid)
         self.unique_name = os.path.join(dirname,
-                                        "%s%s.%s" % (self.hostname,
-                                                     self.tname,
-                                                     self.pid))
+                                        "%s%s" % (self.hostname,
+                                                  self.unique_id))
         self.timeout = timeout
 
     def acquire(self, timeout=None):

--- a/lockfile/linklockfile.py
+++ b/lockfile/linklockfile.py
@@ -19,7 +19,7 @@ class LinkLockFile(LockBase):
         except IOError:
             raise LockFailed("failed to create %s" % self.unique_name)
 
-        timeout = timeout is not None and timeout or self.timeout
+        timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
         if timeout is not None and timeout > 0:
             end_time += timeout

--- a/lockfile/linklockfile.py
+++ b/lockfile/linklockfile.py
@@ -6,6 +6,7 @@ import os
 from . import (LockBase, LockFailed, NotLocked, NotMyLock, LockTimeout,
                AlreadyLocked)
 
+
 class LinkLockFile(LockBase):
     """Lock access to a file using atomic property of link(2).
 
@@ -70,4 +71,3 @@ class LinkLockFile(LockBase):
     def break_lock(self):
         if os.path.exists(self.lock_file):
             os.unlink(self.lock_file)
-

--- a/lockfile/mkdirlockfile.py
+++ b/lockfile/mkdirlockfile.py
@@ -24,7 +24,7 @@ class MkdirLockFile(LockBase):
                                                       self.pid))
 
     def acquire(self, timeout=None):
-        timeout = timeout is not None and timeout or self.timeout
+        timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
         if timeout is not None and timeout > 0:
             end_time += timeout

--- a/lockfile/pidlockfile.py
+++ b/lockfile/pidlockfile.py
@@ -70,7 +70,7 @@ class PIDLockFile(LockBase):
         the lock could not be acquired.
         """
 
-        timeout = timeout is not None and timeout or self.timeout
+        timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
         if timeout is not None and timeout > 0:
             end_time += timeout

--- a/lockfile/pidlockfile.py
+++ b/lockfile/pidlockfile.py
@@ -15,14 +15,13 @@
 from __future__ import absolute_import
 
 import os
-import sys
 import errno
 import time
 
 from . import (LockBase, AlreadyLocked, LockFailed, NotLocked, NotMyLock,
                LockTimeout)
 
-
+
 class PIDLockFile(LockBase):
     """ Lockfile implemented as a Unix PID file.
 
@@ -37,10 +36,7 @@ class PIDLockFile(LockBase):
     def __init__(self, path, threaded=False, timeout=None):
         # pid lockfiles don't support threaded operation, so always force
         # False as the threaded arg.
-        LockBase.__init__(self, path, False, timeout)
-        dirname = os.path.dirname(self.lock_file)
-        basename = os.path.split(self.path)[-1]
-        self.unique_name = self.path
+        super(PIDLockFile, self).__init__(path, False, timeout)
 
     def read_pid(self):
         """ Get the PID from the lock file.
@@ -69,6 +65,8 @@ class PIDLockFile(LockBase):
         Creates the PID file for this lock, or raises an error if
         the lock could not be acquired.
         """
+        if self.i_am_locking():
+            return
 
         timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
@@ -132,10 +130,10 @@ def read_pid_from_pidfile(pidfile_path):
         pass
     else:
         # According to the FHS 2.3 section on PID files in /var/run:
-        # 
+        #
         #   The file must consist of the process identifier in
         #   ASCII-encoded decimal, followed by a newline character.
-        # 
+        #
         #   Programs that read PID files should be somewhat flexible
         #   in what they accept; i.e., they should ignore extra
         #   whitespace, leading zeroes, absence of the trailing
@@ -170,8 +168,7 @@ def write_pid_to_pidfile(pidfile_path):
     #   example, if crond was process number 25, /var/run/crond.pid
     #   would contain three characters: two, five, and newline.
 
-    pid = os.getpid()
-    line = "%(pid)d\n" % vars()
+    line = "%d\n" % os.getpid()
     pidfile.write(line)
     pidfile.close()
 

--- a/lockfile/sqlitelockfile.py
+++ b/lockfile/sqlitelockfile.py
@@ -50,7 +50,7 @@ class SQLiteLockFile(LockBase):
             atexit.register(os.unlink, SQLiteLockFile.testdb)
 
     def acquire(self, timeout=None):
-        timeout = timeout is not None and timeout or self.timeout
+        timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
         if timeout is not None and timeout > 0:
             end_time += timeout

--- a/lockfile/sqlitelockfile.py
+++ b/lockfile/sqlitelockfile.py
@@ -10,6 +10,7 @@ except NameError:
 
 from . import LockBase, NotLocked, NotMyLock, LockTimeout, AlreadyLocked
 
+
 class SQLiteLockFile(LockBase):
     "Demonstrate SQL-based locking."
 
@@ -34,7 +35,7 @@ class SQLiteLockFile(LockBase):
 
         import sqlite3
         self.connection = sqlite3.connect(SQLiteLockFile.testdb)
-        
+
         c = self.connection.cursor()
         try:
             c.execute("create table locks"
@@ -97,7 +98,7 @@ class SQLiteLockFile(LockBase):
                 if len(rows) == 1:
                     # We're the locker, so go home.
                     return
-                    
+
             # Maybe we should wait a bit longer.
             if timeout is not None and time.time() > end_time:
                 if timeout > 0:
@@ -130,7 +131,7 @@ class SQLiteLockFile(LockBase):
                        "  where lock_file = ?",
                        (self.lock_file,))
         return cursor.fetchone()[0]
-        
+
     def is_locked(self):
         cursor = self.connection.cursor()
         cursor.execute("select * from locks"

--- a/lockfile/symlinklockfile.py
+++ b/lockfile/symlinklockfile.py
@@ -21,7 +21,7 @@ class SymlinkLockFile(LockBase):
         #    open(self.unique_name, "wb").close()
         #except IOError:
         #    raise LockFailed("failed to create %s" % self.unique_name)
-        timeout = timeout is not None and timeout or self.timeout
+        timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
         if timeout is not None and timeout > 0:
             end_time += timeout

--- a/test/compliancetest.py
+++ b/test/compliancetest.py
@@ -1,142 +1,100 @@
+from functools import wraps
 import os
 import threading
 import shutil
 
 import lockfile
 
-class ComplianceTest(object):
-    def __init__(self):
-        self.saved_class = lockfile.LockFile
 
-    def _testfile(self):
-        """Return platform-appropriate file.  Helper for tests."""
-        import tempfile
-        return os.path.join(tempfile.gettempdir(), 'trash-%s' % os.getpid())
+def acquire_lock_in_first_thread(func):
+    """
+    Decorator for use on ComplianceTest class/subclasses methods to factor
+    out broiler plate code of grabbing a lock with one thread and creating
+    a second lock to pass as an arument to the decorated test method.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwds):
+        e1, e2 = threading.Event(), threading.Event()
+        t = _in_thread(self._lock_wait_unlock, e1, e2, self.threaded)
+        e1.wait()                # wait for thread t to acquire lock
+        lock2 = self.class_to_test(self.test_file, threaded=self.threaded)
+        assert lock2.is_locked()
+
+        return func(self, lock2, *args, **kwds)
+
+        e2.set()
+        t.join()
+    return wrapper
+
+
+class ComplianceTest(object):
+
+    threaded = None
+
+    def _lock_wait_unlock(self, event1, event2, tbool):
+        """Lock from another thread.  Helper for tests."""
+        l = self.class_to_test(self.test_file, threaded=tbool)
+        l.acquire()
+        try:
+            event1.set()  # we're in,
+            event2.wait() # wait for boss's permission to leave
+        finally:
+            l.release()
 
     def setup(self):
-        lockfile.LockFile = self.class_to_test
+        """
+        Make a temporary directory for placing files in and calculate a test
+        file path to pass when creating LockFile objects.
+        """
+        import tempfile
+        self.test_dir = os.path.join(tempfile.gettempdir(),
+                                     'trash-%s' % os.getpid())
+        os.makedirs(self.test_dir)
+        self.test_file = os.path.join(self.test_dir, 'testfile-%s' % os.getpid())
 
     def teardown(self):
-        try:
-            tf = self._testfile()
-            if os.path.isdir(tf):
-                shutil.rmtree(tf)
-            elif os.path.isfile(tf):
-                os.unlink(tf)
-            elif not os.path.exists(tf):
-                pass
-            else:
-                raise SystemError("unrecognized file: %s" % tf)
-        finally:
-            lockfile.LockFile = self.saved_class
+        shutil.rmtree(self.test_dir)
 
-    def _test_acquire_helper(self, tbool):
-        # As simple as it gets.
-        lock = lockfile.LockFile(self._testfile(), threaded=tbool)
+    def _assert_already_locked(self, lock, timeout):
+        try:
+            lock.acquire(timeout=timeout)
+        except lockfile.AlreadyLocked:
+            pass
+        else:
+            lock.release()
+            raise AssertionError("did not raise AlreadyLocked in"
+                                 " thread %s" %
+                                 threading.current_thread().get_name())
+
+    def _assert_lock_timeout(self, lock, timeout):
+        try:
+            lock.acquire(timeout=timeout)
+        except lockfile.LockTimeout:
+            pass
+        else:
+            lock.release()
+            raise AssertionError("did not raise LockTimeout in thread %s" %
+                                 threading.current_thread().get_name())
+
+    def _assert_lock_acquired(self, lock, timeout):
+        lock.acquire(timeout=timeout)
+        assert lock.is_locked()
+        assert lock.i_am_locking()
+
+    def test_single_lock_acquire(self):
+        lock = self.class_to_test(self.test_file, threaded=self.threaded)
+        assert not lock.is_locked()
+        assert not lock.i_am_locking()
         lock.acquire()
+        assert lock.is_locked()
         assert lock.i_am_locking()
         lock.release()
         assert not lock.is_locked()
+        assert not lock.i_am_locking()
 
-##    def test_acquire_basic_threaded(self):
-##        self._test_acquire_helper(True)
-
-    def test_acquire_basic_unthreaded(self):
-        self._test_acquire_helper(False)
-
-    def _test_acquire_no_timeout_helper(self, tbool):
-        # No timeout test
-        e1, e2 = threading.Event(), threading.Event()
-        t = _in_thread(self._lock_wait_unlock, e1, e2)
-        e1.wait()         # wait for thread t to acquire lock
-        lock2 = lockfile.LockFile(self._testfile(), threaded=tbool)
-        assert lock2.is_locked()
-        if tbool:
-            assert not lock2.i_am_locking()
-        else:
-            assert lock2.i_am_locking()
-
-        try:
-            lock2.acquire(timeout=-1)
-        except lockfile.AlreadyLocked:
-            pass
-        else:
-            lock2.release()
-            raise AssertionError("did not raise AlreadyLocked in"
-                                 " thread %s" %
-                                 threading.current_thread().get_name())
-
-        try:
-            lock2.acquire(timeout=0)
-        except lockfile.AlreadyLocked:
-            pass
-        else:
-            lock2.release()
-            raise AssertionError("did not raise AlreadyLocked in"
-                                 " thread %s" %
-                                 threading.current_thread().get_name())
-
-        e2.set()          # tell thread t to release lock
-        t.join()
-
-##    def test_acquire_no_timeout_threaded(self):
-##        self._test_acquire_no_timeout_helper(True)
-
-##    def test_acquire_no_timeout_unthreaded(self):
-##        self._test_acquire_no_timeout_helper(False)
-
-    def _test_acquire_timeout_helper(self, tbool):
-        # Timeout test
-        e1, e2 = threading.Event(), threading.Event()
-        t = _in_thread(self._lock_wait_unlock, e1, e2)
-        e1.wait()                # wait for thread t to acquire lock
-        lock2 = lockfile.LockFile(self._testfile(), threaded=tbool)
-        assert lock2.is_locked()
-        try:
-            lock2.acquire(timeout=0.1)
-        except lockfile.LockTimeout:
-            pass
-        else:
-            lock2.release()
-            raise AssertionError("did not raise LockTimeout in thread %s" %
-                                 threading.current_thread().get_name())
-
-        e2.set()
-        t.join()
-
-    def test_acquire_timeout_threaded(self):
-        self._test_acquire_timeout_helper(True)
-
-    def test_acquire_timeout_unthreaded(self):
-        self._test_acquire_timeout_helper(False)
-
-    def _test_context_timeout_helper(self, tbool):
-        # Timeout test
-        e1, e2 = threading.Event(), threading.Event()
-        t = _in_thread(self._lock_wait_unlock, e1, e2)
-        e1.wait()                # wait for thread t to acquire lock
-        lock2 = lockfile.LockFile(self._testfile(), threaded=tbool,
-                                  timeout=0.2)
-        assert lock2.is_locked()
-        try:
-            lock2.acquire()
-        except lockfile.LockTimeout:
-            pass
-        else:
-            lock2.release()
-            raise AssertionError("did not raise LockTimeout in thread %s" %
-                                 threading.current_thread().get_name())
-
-        e2.set()
-        t.join()
-
-    def test_context_timeout_unthreaded(self):
-        self._test_context_timeout_helper(False)
-
-    def _test_release_basic_helper(self, tbool):
-        lock = lockfile.LockFile(self._testfile(), threaded=tbool)
+    def test_multiple_release(self):
+        lock = self.class_to_test(self.test_file, threaded=self.threaded)
         lock.acquire()
-        assert lock.is_locked()
         lock.release()
         assert not lock.is_locked()
         assert not lock.i_am_locking()
@@ -150,67 +108,14 @@ class ComplianceTest(object):
         else:
             raise AssertionError('erroneously unlocked file')
 
-##    def test_release_basic_threaded(self):
-##        self._test_release_basic_helper(True)
-
-    def test_release_basic_unthreaded(self):
-        self._test_release_basic_helper(False)
-
-##    def test_release_from_thread(self):
-##        e1, e2 = threading.Event(), threading.Event()
-##        t = _in_thread(self._lock_wait_unlock, e1, e2)
-##        e1.wait()
-##        lock2 = lockfile.LockFile(self._testfile(), threaded=False)
-##        assert not lock2.i_am_locking()
-##        try:
-##            lock2.release()
-##        except lockfile.NotMyLock:
-##            pass
-##        else:
-##            raise AssertionError('erroneously unlocked a file locked'
-##                                 ' by another thread.')
-##        e2.set()
-##        t.join()
-
-    def _test_is_locked_helper(self, tbool):
-        lock = lockfile.LockFile(self._testfile(), threaded=tbool)
-        lock.acquire(timeout=2)
-        assert lock.is_locked()
-        lock.release()
-        assert not lock.is_locked(), "still locked after release!"
-
-##    def test_is_locked_threaded(self):
-##        self._test_is_locked_helper(True)
-
-    def test_is_locked_unthreaded(self):
-        self._test_is_locked_helper(False)
-
-##    def test_i_am_locking_threaded(self):
-##        self._test_i_am_locking_helper(True)
-
-    def test_i_am_locking_unthreaded(self):
-        self._test_i_am_locking_helper(False)
-
-    def _test_i_am_locking_helper(self, tbool):
-        lock1 = lockfile.LockFile(self._testfile(), threaded=tbool)
-        assert not lock1.is_locked()
-        lock1.acquire()
-        try:
-            assert lock1.i_am_locking()
-            lock2 = lockfile.LockFile(self._testfile(), threaded=tbool)
-            assert lock2.is_locked()
-            if tbool:
-                assert not lock2.i_am_locking()
-        finally:
-            lock1.release()
-
-    def _test_break_lock_helper(self, tbool):
-        lock = lockfile.LockFile(self._testfile(), threaded=tbool)
+    def test_break_lock(self):
+        lock = self.class_to_test(self.test_file, threaded=self.threaded)
         lock.acquire()
         assert lock.is_locked()
-        lock2 = lockfile.LockFile(self._testfile(), threaded=tbool)
+        lock2 = self.class_to_test(self.test_file, threaded=self.threaded)
         assert lock2.is_locked()
         lock2.break_lock()
+        assert not lock.is_locked()
         assert not lock2.is_locked()
         try:
             lock.release()
@@ -219,36 +124,99 @@ class ComplianceTest(object):
         else:
             raise AssertionError('break lock failed')
 
-##    def test_break_lock_threaded(self):
-##        self._test_break_lock_helper(True)
-
-    def test_break_lock_unthreaded(self):
-        self._test_break_lock_helper(False)
-
-    def _lock_wait_unlock(self, event1, event2):
-        """Lock from another thread.  Helper for tests."""
-        l = lockfile.LockFile(self._testfile())
-        l.acquire()
-        try:
-            event1.set()  # we're in,
-            event2.wait() # wait for boss's permission to leave
-        finally:
-            l.release()
-
-    def test_enter(self):
-        lock = lockfile.LockFile(self._testfile())
-        lock.acquire()
-        try:
-            assert lock.is_locked(), "Not locked after acquire!"
-        finally:
-            lock.release()
-        assert not lock.is_locked(), "still locked after release!"
-
     def test_decorator(self):
-        @lockfile.locked(self._testfile())
+        @lockfile.locked(self.test_file)
         def func(a, b):
             return a + b
         assert func(4, 3) == 7
+
+    def test_context_manager(self):
+        with lockfile.LockFile(self.test_file) as lock:
+            assert lock.is_locked()
+            assert lock.i_am_locking()
+        assert not lock.is_locked()
+        assert not lock.i_am_locking()
+
+
+class NonThreadDistinguishingTest(ComplianceTest):
+    """
+    Assertion tests for Lockfile objects that DO NOT distinguish between
+    threads in the same process.
+    """
+
+    threaded = False
+
+    @acquire_lock_in_first_thread
+    def test_acquire_with_zero_timeeout(self, lock2):
+        assert lock2.i_am_locking()
+        self._assert_lock_acquired(lock2, 0)
+
+    @acquire_lock_in_first_thread
+    def test_acquire_with_negative_timeout(self, lock2):
+        assert lock2.i_am_locking()
+        self._assert_lock_acquired(lock2, -1)
+
+    @acquire_lock_in_first_thread
+    def test_acquire_with_positive_timeout(self, lock2):
+        assert lock2.i_am_locking()
+        self._assert_lock_acquired(lock2, 0.1)
+
+    @acquire_lock_in_first_thread
+    def test_init_with_positive_timeout(self, lock2):
+        lock3 = self.class_to_test(self.test_file, threaded=self.threaded,
+                                   timeout=0.2)
+        assert lock3.is_locked()
+        self._assert_lock_acquired(lock3, None)
+
+    @acquire_lock_in_first_thread
+    def test_release_from_other_lock(self, lock2):
+        assert lock2.i_am_locking()
+        lock2.release()
+        assert not lock2.is_locked()
+        assert not lock2.i_am_locking()
+
+
+class ThreadDistinguishingTest(ComplianceTest):
+    """
+    Assertion tests for Lockfile objects that DO distinguish between
+    threads in the same process.
+    """
+
+    threaded = True
+
+    @acquire_lock_in_first_thread
+    def test_acquire_with_zero_timeout(self, lock2):
+        assert not lock2.i_am_locking()
+        self._assert_already_locked(lock2, 0)
+
+    @acquire_lock_in_first_thread
+    def test_acquire_with_negative_timeout(self, lock2):
+        assert not lock2.i_am_locking()
+        self._assert_already_locked(lock2, -1)
+
+    @acquire_lock_in_first_thread
+    def test_acquire_with_positive_timeout(self, lock2):
+        assert not lock2.i_am_locking()
+        self._assert_lock_timeout(lock2, 0.1)
+
+    @acquire_lock_in_first_thread
+    def test_init_with_positive_timeout(self, lock2):
+        lock3 = self.class_to_test(self.test_file, threaded=self.threaded,
+                                   timeout=0.2)
+        assert lock3.is_locked()
+        self._assert_lock_timeout(lock3, None)
+
+    @acquire_lock_in_first_thread
+    def test_release_from_other_lock(self, lock2):
+        assert not lock2.i_am_locking()
+        try:
+            lock2.release()
+        except lockfile.NotMyLock:
+            pass
+        else:
+            raise AssertionError('erroneously unlocked a file locked'
+                                 ' by another thread.')
+
 
 def _in_thread(func, *args, **kwargs):
     """Execute func(*args, **kwargs) after dt seconds. Helper for tests."""
@@ -258,4 +226,3 @@ def _in_thread(func, *args, **kwargs):
     t.setDaemon(True)
     t.start()
     return t
-

--- a/test/test_lockfile.py
+++ b/test/test_lockfile.py
@@ -1,30 +1,49 @@
-import sys
-
 import lockfile.linklockfile
 import lockfile.mkdirlockfile
 import lockfile.pidlockfile
 import lockfile.symlinklockfile
 
-from compliancetest import ComplianceTest
-    
-class TestLinkLockFile(ComplianceTest):
+from compliancetest import NonThreadDistinguishingTest, ThreadDistinguishingTest
+
+
+class TestLinkLockFile(NonThreadDistinguishingTest):
+    class_to_test = lockfile.linklockfile.LinkLockFile
+class TestLinkLockFileThreaded(ThreadDistinguishingTest):
     class_to_test = lockfile.linklockfile.LinkLockFile
 
-class TestSymlinkLockFile(ComplianceTest):
+
+class TestSymlinkLockFile(NonThreadDistinguishingTest):
+    class_to_test = lockfile.symlinklockfile.SymlinkLockFile
+class TestSymlinkLockFileThreaded(ThreadDistinguishingTest):
     class_to_test = lockfile.symlinklockfile.SymlinkLockFile
 
-class TestMkdirLockFile(ComplianceTest):
+
+class TestMkdirLockFile(NonThreadDistinguishingTest):
+    class_to_test = lockfile.mkdirlockfile.MkdirLockFile
+class TestMkdirLockFileThreaded(ThreadDistinguishingTest):
     class_to_test = lockfile.mkdirlockfile.MkdirLockFile
 
-class TestPIDLockFile(ComplianceTest):
+
+class TestPIDLockFile(NonThreadDistinguishingTest):
     class_to_test = lockfile.pidlockfile.PIDLockFile
+# PIDLockFile class does not currently support distinguishing between threads.
+# Could be possible if both the pid and thread id was written to the PID file.
+#class TestPIDLockFileThreaded(ThreadDistinguishingTest):
+#    class_to_test = lockfile.pidlockfile.PIDLockFile
+
 
 # Check backwards compatibility
-class TestLinkFileLock(ComplianceTest):
+class TestLinkFileLock(NonThreadDistinguishingTest):
+    class_to_test = lockfile.LinkFileLock
+class TestLinkFileLockThreaded(ThreadDistinguishingTest):
     class_to_test = lockfile.LinkFileLock
 
-class TestMkdirFileLock(ComplianceTest):
+
+class TestMkdirFileLock(NonThreadDistinguishingTest):
     class_to_test = lockfile.MkdirFileLock
+class TestMkdirFileLockThreaded(ThreadDistinguishingTest):
+    class_to_test = lockfile.MkdirFileLock
+
 
 try:
     import sqlite3
@@ -32,5 +51,9 @@ except ImportError:
     pass
 else:
     import lockfile.sqlitelockfile
-    class TestSQLiteLockFile(ComplianceTest):
+    class TestSQLiteLockFile(NonThreadDistinguishingTest):
         class_to_test = lockfile.sqlitelockfile.SQLiteLockFile
+# TODO: Seems that the SQLiteLockFile class should handle distinguishing
+# between threads, but these tests currently failing.
+#    class TestSQLiteLockFileThreaded(ThreadDistinguishingTest):
+#        class_to_test = lockfile.sqlitelockfile.SQLiteLockFile

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py26,py27,py32,py33
+envlist = py26,py27,py32,py33,py34
+
 [testenv]
 deps = nose
-commands=nosetests
+commands=nosetests -v
+
+[testenv:py34]
+basepython = python3.4


### PR DESCRIPTION
Summary of changes:
- Tests refactored to remove duplication and split into two classes (one for threaded distinction and one for non-threaded distinction) for localizing the differences between the behavior in each style of operation.
- The previous fix for the timeout=0 bug still exhibited the same bug as before.  Switched to using a conditional expression instead of relying on short-circuit logic.
- The PIDLockFile class was throwing an error when subsequently acquiring the lock in the same process/thread, complaining that the file already existed.  To fix this, I added a check in acquire that returns immediately if self.i_am_locking() is True.
- Added Python 3.4 to the tox config.
